### PR TITLE
Add support for version 7

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
-datadog_agent_checks_config_dir: "/etc/dd-agent/conf.d"
+datadog_agent_legacy_checks_config_dir: "/etc/dd-agent/conf.d"
+datadog_config_path: "/etc/datadog-agent"
 datadog_user: dd-agent
 datadog_group: dd-agent

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,15 +1,42 @@
 ---
-- name: "Create {{ item }} DataDog check configuration file"
-  template:
-    src: checks.yml.j2
-    dest: "{{ datadog_agent_checks_config_dir }}/{{ item }}.yaml"
-    owner: "{{ datadog_user }}"
-    group: "{{ datadog_group }}"
-  with_items: "{{ datadog_checks | list }}"
+- block:
+    - block:  
+        - name: check current running datadog-agent version
+          shell: "dpkg -s datadog-agent | grep Version -m 1 | awk '{print $2}'"
+          register: installed_dd_agent_version
 
-- name: "Display DataDog checks configurations"
-  debug:
-    msg: "{{ lookup('file',item).split('\n') }}"
-    verbosity: 2
-  with_fileglob:
-    - "{{ datadog_agent_checks_config_dir }}/*.yaml"
+    - block: # when datadog-agent version < 6
+
+        - name: "Create {{ item }} DataDog v5 check configuration file"
+          template:
+            src: checks.yml.j2
+            dest: "{{ datadog_agent_checks_config_dir }}/{{ item }}.yaml"
+            owner: "{{ datadog_user }}"
+            group: "{{ datadog_group }}"
+          with_items: "{{ datadog_checks | list }}"
+
+        - name: "Display DataDog checks configurations"
+          debug:
+            msg: "{{ lookup('file',item).split('\n') }}"
+            verbosity: 2
+          with_fileglob:
+            - "{{ datadog_agent_checks_config_dir }}/*.yaml"
+
+      when: (datadog_check_version | default(installed_dd_agent_version)) is version('1:6', 'lt')
+
+    - block: # when datadog-agent version > 6
+
+        - name: "Create {{ item }} DataDog v6+ check configuration file"
+          template:
+            src: checks.yml.j2
+            dest: "{{ datadog_config_path }}/conf.d/{{ item }}.d/{{ item }}.yaml"
+            owner: "{{ datadog_user }}"
+            group: "{{ datadog_group }}"
+          with_items: "{{ datadog_checks | list }}"
+
+        - name: "Display DataDog checks configurations"
+          shell: ls -1 {{ datadog_config_path }}/conf.d/*.d/*.yaml
+
+      when: (datadog_check_version | default(installed_dd_agent_version)) is version('1:6', 'ge')
+
+  become: true

--- a/tests/test-non-travis.yml
+++ b/tests/test-non-travis.yml
@@ -1,14 +1,7 @@
 ---
 - hosts: all
-  become: True
-  vars:
-    datadog_check_version: "1:7.21.1-1"
   roles:
     - name: ansible-datadog-checks
-      datadog_agent_legacy_checks_config_dir: "{{ lookup('env','TRAVIS_BUILD_DIR') }}"
-      datadog_config_path: "{{ lookup('env','TRAVIS_BUILD_DIR') }}"
-      datadog_user: "{{ lookup('env','USER') }}"
-      datadog_group: root
       datadog_checks:
         jmx:
           init_config: null

--- a/tests/test-non-travis.yml
+++ b/tests/test-non-travis.yml
@@ -1,7 +1,8 @@
 ---
 - hosts: all
   roles:
-    - name: ansible-datadog-checks
+    - name: ../../ansible-datadog-checks
+      datadog_check_version: "1:7.32.2-1"
       datadog_checks:
         jmx:
           init_config: null


### PR DESCRIPTION
# Summary
Resolves #1

# Changes
- [Breaking] Rename default var `datadog_agent_checks_config_dir` to `datadog_agent_legacy_checks_config_dir`
- Add conditional tasks for version <6 and version >= 6
- Using var `datadog_config_path` instead of "dir" to follow same variable naming as ansible-datadog-agent
- Using `ls` command to show installed checks because `with_file_glob` doesn't support recursive lookup more than 1 directory depth.